### PR TITLE
 Support for multiple Phidgets of same type

### DIFF
--- a/phidgetAPI.js
+++ b/phidgetAPI.js
@@ -74,11 +74,14 @@ function phidgetConnection(){
 
                 phidget.client.write('report 8 report\r\n');
 
-                phidget.client.write(
-                    'set /PCK/Client/0.0.0.0/1/'+
-                    phidget.params.type+
-                    '="Open" for session\r\n'
-                );
+				var randInt = parseInt(Math.random() * 99999, 10),
+					openStr = 'set /PCK/Client/0.0.0.0/' + randInt + '/' + phidget.params.type + '="Open" for session\r\n',
+					listenStr = 'listen /PSK/' + phidget.params.type + ' lid0\r\n';
+				if (phidget.params.boardID) {
+					openStr = 'set /PCK/Client/0.0.0.0/' + randInt + '/' + phidget.params.type + '/' + phidget.params.boardID + '="Open" for session\r\n';
+					listenStr = 'listen /PSK/' + phidget.params.type + '//' + phidget.params.boardID + ' lid0\r\n';
+				}	
+                phidget.client.write(openStr);
                 
                 if(phidget.params.type=='PhidgetManager'){
                     phidget.client.write(
@@ -88,11 +91,7 @@ function phidgetConnection(){
                     return;
                 }
                 
-                phidget.client.write(
-                    'listen /PSK/'+
-                    phidget.params.type+
-                    ' lid0\r\n'
-                );
+                phidget.client.write(listenStr);
                 
             }
         );	


### PR DESCRIPTION
Added support for multiple Phidgets of the same type using boardID(serial number)  as the differentiator.
Passing boardID in the init params will create a unique send\listen connection to the Phidget webservice.
Example is the Phidget SBC with inbuilt 8/8/8 InterfaceKit has the same type as the Phidget 0/0/8 Interfacekit - [PhidgetInterfaceKit].

So adding the boardID into the connect method params allows both Phidgets to be accessed.

example connect

intkit.connect({
    host: '127.0.0.1',
    port: 5001,
    version: '1.0.10', //older phidgetwebservice installs may require 1.0.9
    password: null,
    type: 'PhidgetInterfaceKit',
    boardID: 339481,
    rawLog: false
});

intkit2.connect({
    host: '127.0.0.1',
    port: 5001,
    version: '1.0.10', //older phidgetwebservice installs may require 1.0.9
    password: null,
    type: 'PhidgetInterfaceKit',
    boardID: 313651,
    rawLog: false
});

The boardID can be omitted if there is only one Phidget device of that type.
